### PR TITLE
Use shields for PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![PyPI version](https://badge.fury.io/py/calibr8.svg)](https://badge.fury.io/py/calibr8)
+[![PyPI version](https://img.shields.io/pypi/v/calibr8)](https://pypi.org/project/calibr8)
 [![pipeline](https://github.com/michaelosthege/calibr8/workflows/pipeline/badge.svg)](https://github.com/michaelosthege/calibr8/actions)
 [![coverage](https://codecov.io/gh/michaelosthege/calibr8/branch/master/graph/badge.svg)](https://codecov.io/gh/michaelosthege/calibr8)
 [![documentation](https://readthedocs.org/projects/calibr8/badge/?version=latest)](https://calibr8.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
The fury badge was slow and the link was slow too.

I switched to shields.io also for `hagelkorn`: https://raw.githubusercontent.com/michaelosthege/hagelkorn/master/README.md